### PR TITLE
Clarify instructions and remove outdated comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ VisIT plugins for visualization of VisIt gr3, prop and output files
 
 Install instructions tested with VisIt 3.1.4
 - [install-macm1-visit3.1.4](install-macm1-visit3.1.4.md) - Installing on a Mac with an M1 chip but targeting x86_64 architecture
+- [install-expanse](install-expanse.md) - Installing to a home directory on Expanse at SDSC to use VisIt in client-server mode
 - [install-ubuntu20-visit3.1.4](install-ubuntu20-visit3.1.4.md) - Installing on Ubuntu 20
 
 Get sample inputs here: [SCHISM Visualization](https://schism-dev.github.io/schism/master/getting-started/visualization.html#visualization-with-visit)

--- a/install-expanse.md
+++ b/install-expanse.md
@@ -1,10 +1,14 @@
-You can install the plugin in your home directory.
+# Installing on Expanse (SDSC)
 
-# Set the VisIt environment
+VisIt 3.1.4 is installed on Expanse.  You can install the plugin in your home directory.
 
-Currently, there is no 'visit' module, and I think that is because you should only use it in client-server mode.  But we need the xml stuff to compile the plugins.
+When using client-server mode, the local VisIt(client) must use the same VisIt as the HPC(server).  To use Expanse client-server VisIt (as of 6/30/2023), you must also install this plugin on your local machine with VisIt 3.1.4. 
 
-The instructions for running in client-server mode is here: `/cm/shared/examples/sdsc/visit/README`.
+## Set the VisIt environment
+
+Currently, there is no 'visit' module, so we need to set the environment by adding the path to VisIt's xml commands used to compile the plugins.
+
+The instructions for running in client-server mode are here: `/cm/shared/examples/sdsc/visit/README`.
 
 From that, you can get the path: `/cm/shared/apps/vis/visit/3.1.4/gcc/9.2.0/openmpi/3.1.6/3.1.4/linux-x86_64/bin`, which indicates that VisIt 3.1.4 was compiled with gcc 9.2.0 and openmpi 3.1.6.
 
@@ -40,13 +44,13 @@ If you don't want to make a module, do:
 export PATH=/cm/shared/apps/vis/visit/3.1.4/gcc/9.2.0/openmpi/3.1.6/3.1.4/linux-x86_64/bin:$PATH
 ```
 
-# Install the plugin
+## Install the plugin
 
 Now try the steps to install the plugin.
 
-Get the plugin code.  This one test *my* plugin code with the malloc.h in ifdef statements:
+Get the plugin code.
 ```
-git clone https://github.com/lisalenorelowe/schism_visit_plugin.git
+git clone https://github.com/schism-dev/schism_visit_plugin.git
 cd schism_visit_plugin
 ```
 

--- a/install-macm1-visit3.1.4.md
+++ b/install-macm1-visit3.1.4.md
@@ -1,39 +1,47 @@
 # Installing on Mac Studio
 
-Installing on my Mac Studio that has an M1 chip.
+Instructions for installing the SCHISM plugins for VisIt 3.1.4 on a Mac Studio that has an M1 chip.
 
-Using VisIt 3.1.4, to use client-server mode from Expanse, which is only available as x86_64.
+We are using VisIt 3.1.4 to use client-server mode from Expanse.  The local VisIt(client) must use the same VisIt as the HPC(server). Older versions of VisIt(pre-M1) are only available as x86, so an extra CMAKE flag is needed to compile for x86 instead of the default arm(M1) processor.
 
-Download CMake for Mac, drag it into the applications bin.  Open CMake, in the top menu bar, click Tools, 
+
+## Install VisIt 3.1.4
+
+First, install VisIt 3.1.4 in the usual Mac way: [download](https://visit-dav.github.io/visit-website/releases-as-tables/#series-31), click, drag to applications. Test it by clicking on the application icon to open VisIt, then close VisIt.
+
+To follow the instructions below, VisIt must be in the path.  If you open a terminal and type `visit`, it will probably say `command not found: visit`.  The VisIt executable is usually here: `/Applications/VisIt.app/Contents/Resources/bin`.  Confirm the following opens VisIt.
+```
+/Applications/VisIt.app/Contents/Resources/bin/visit
+```
+
+To avoid typing the whole filepath, add VisIt to your PATH by doing:
+```
+export PATH="/Applications/VisIt.app/Contents/Resources/bin:$PATH"
+visit
+```
+
+That PATH will only be valid while that terminal is open.  To add an additional executable path to your environment, add it to the 'dot' file for your shell, which (unless you changed your default shell), is the file `~/.zshrc`.  Open `~/.zshrc` and add the following, 
+```
+export PATH="/Applications/VisIt.app/Contents/Resources/bin:$PATH"
+```
+
+Exit the terminal and open a new one.  Now, `visit` should be in your path.  The command `xml2plugin` used below is a VisIt command.  To confirm that both are in your path, do:
+```
+which visit
+which xml2plugin
+```
+
+If that was successful, you're ready to move on.
+
+## Get CMake
+
+[Download CMake](https://cmake.org/download/) for Mac, drag it into the applications bin.  Open CMake, in the top menu bar, click Tools, 
 choose How to Install For Command Line Use.  I chose this way:
 ```
 sudo "/Applications/CMake.app/Contents/bin/cmake-gui" --install
 ```
 
-When compiling, I got a bunch of errors because of `malloc.h`.  Searching on the internets, I found [this possible solution](https://github.com/RIOT-OS/RIOT/issues/2361).
-So for every subroutine where there is `malloc.h`, I did this:
-```
-#if defined(__MACH__)
-#include <stdlib.h>
-#else
-#include <malloc.h>
-#endif
-```
-These were the files:
-```
-(base) lllowe@LisasMacStudio schism_visit_plugin % grep malloc.h */*
-mdschism/avtMDSCHISMFileFormatImpl.C
-unstructure_data/avtSCHISMFileFormat.C
-unstructure_data/avtSCHISMFileFormatImpl.C
-unstructure_data/avtSCHISMFileFormatImpl10.C
-unstructure_data/avtSCHISMFileFormatImpl11.C
-```
-
-On my fork, it is fixed, so get that one:
-```
-git clone https://github.com/lisalenorelowe/schism_visit_plugin.git
-cd schism_visit_plugin
-```
+## Install the plugins
 
 Install the unstructure_data plugin:
 ```


### PR DESCRIPTION
Additional instructions for Mac, clarifying the need to first install VisIt, and instructions on setting the PATH in order to use xml2 from the command line.  Removes references to 'malloc' problem, which was fixed in the latest schism-dev release, and changes git clone links from the l3 forked repo to the main schism-dev repo.  Adds a link for install-expanse.md to the README's table of contents.